### PR TITLE
set struct Item as the IsExpire() method's receiver

### DIFF
--- a/item/item.go
+++ b/item/item.go
@@ -11,6 +11,6 @@ type Item struct {
 }
 
 // check expire cache
-func IsExpire(t time.Time) bool {
-	return t.Before(time.Now().Local())
+func (i Item) IsExpire() bool {
+	return i.Expire.Before(time.Now().Local())
 }

--- a/mcache.go
+++ b/mcache.go
@@ -44,7 +44,7 @@ func (mc *CacheDriver) Get(key string, struc interface{}) bool {
 		return false
 	}
 	item := data.(entity.Item)
-	if entity.IsExpire(item.Expire) {
+	if item.IsExpire() {
 		return false
 	}
 	err := decodeBytes(item.Data, struc)
@@ -61,7 +61,7 @@ func (mc *CacheDriver) GetPointer(key string) (interface{}, bool) {
 		return entity.Item{}.DataLink, false
 	}
 	item := data.(entity.Item)
-	if entity.IsExpire(item.Expire) {
+	if item.IsExpire() {
 		return entity.Item{}.DataLink, false
 	}
 	return item.DataLink, true

--- a/safeMap/safe.go
+++ b/safeMap/safe.go
@@ -118,7 +118,7 @@ func flush(s map[string]interface{}, keys []string) {
 		if !ok {
 			continue
 		}
-		if entity.IsExpire(value.(entity.Item).Expire) {
+		if value.(entity.Item).IsExpire() {
 			delete(s, v)
 		}
 	}


### PR DESCRIPTION
so we can:
- reduce if-clauses to check if the item is expired
- refuse to use the field Item.Expire unnecessarily