### PR TITLE
fix: prevent GC goroutines from busy-looping at 100% CPU

### DIFF
--- a/gcmap/gcmap_worker.go
+++ b/gcmap/gcmap_worker.go
@@ -1,273 +1,230 @@
 package gcmap
 
-import (
-	"container/heap"
-	"context"
-	"sync"
-	"time"
+  import (
+        "container/heap"
+        "context"
+        "sync"
+        "time"
 
-	"github.com/OrlovEvgeny/go-mcache/safeMap"
-)
+        "github.com/OrlovEvgeny/go-mcache/safeMap"
+  )
 
-// expiryItem represents a cache key and its expiration time for use in a min-heap.
-type expiryItem struct {
-	key      string    // Cache key
-	expireAt time.Time // Expiration timestamp
-	index    int       // Position in the heap
-}
+  // expiryItem represents a cache key and its expiration time for use in a min-heap.
+  type expiryItem struct {
+        key      string    // Cache key
+        expireAt time.Time // Expiration timestamp
+        index    int       // Position in the heap
+  }
 
-// expiryHeap implements a min-heap of expiryItems.
-type expiryHeap []*expiryItem
+  // expiryHeap implements a min-heap of expiryItems.
+  type expiryHeap []*expiryItem
 
-func (h expiryHeap) Len() int           { return len(h) }
-func (h expiryHeap) Less(i, j int) bool { return h[i].expireAt.Before(h[j].expireAt) }
-func (h expiryHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i]; h[i].index = i; h[j].index = j }
-func (h *expiryHeap) Push(x interface{}) {
-	item := x.(*expiryItem)
-	item.index = len(*h)
-	*h = append(*h, item)
-}
-func (h *expiryHeap) Pop() interface{} {
-	old := *h
-	n := len(old)
-	item := old[n-1]
-	old[n-1] = nil  // Prevent memory leak
-	item.index = -1 // Invalidate index
-	*h = old[0 : n-1]
-	return item
-}
+  func (h expiryHeap) Len() int           { return len(h) }
+  func (h expiryHeap) Less(i, j int) bool { return h[i].expireAt.Before(h[j].expireAt) }
+  func (h expiryHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i]; h[i].index = i; h[j].index = j }
+  func (h *expiryHeap) Push(x interface{}) {
+        item := x.(*expiryItem)
+        item.index = len(*h)
+        *h = append(*h, item)
+  }
+  func (h *expiryHeap) Pop() interface{} {
+        old := *h
+        n := len(old)
+        item := old[n-1]
+        old[n-1] = nil  // Prevent memory leak
+        item.index = -1 // Invalidate index
+        *h = old[0 : n-1]
+        return item
+  }
 
-// GC handles automatic expiration of entries in SafeMap using a heap-based scheduler.
-type GC struct {
-	storage    safeMap.SafeMap
-	mu         sync.Mutex
-	pq         expiryHeap             // Min-heap of pending expirations
-	keys       map[string]*expiryItem // Map of keys to the pending expirations pointers
-	timer      *time.Timer
-	stopSignal chan struct{}
-	wakeSignal chan struct{} // Signal to recalculate timer early
-	wg         sync.WaitGroup
-	options    gcOptions
-}
+  // GC handles automatic expiration of entries in SafeMap using a heap-based scheduler.
+  type GC struct {
+        storage    safeMap.SafeMap
+        mu         sync.Mutex
+        pq         expiryHeap             // Min-heap of pending expirations
+        keys       map[string]*expiryItem // Map of keys to the pending expirations pointers
+        stopSignal chan struct{}
+        wakeSignal chan struct{} // Signal to recalculate timer early
+        wg         sync.WaitGroup
+        options    gcOptions
+  }
 
-type gcOptions struct {
-	defaultPollInterval time.Duration // Fallback interval when heap is empty
-}
+  type gcOptions struct {
+        defaultPollInterval time.Duration // Fallback interval when heap is empty
+  }
 
-// GCOption customizes GC behavior.
-type GCOption func(*gcOptions)
+  // GCOption customizes GC behavior.
+  type GCOption func(*gcOptions)
 
-// WithPollInterval sets the fallback sleep interval.
-func WithPollInterval(d time.Duration) GCOption {
-	return func(o *gcOptions) {
-		if d > 0 {
-			o.defaultPollInterval = d
-		}
-	}
-}
+  // WithPollInterval sets the fallback sleep interval.
+  func WithPollInterval(d time.Duration) GCOption {
+        return func(o *gcOptions) {
+                if d > 0 {
+                        o.defaultPollInterval = d
+                }
+        }
+  }
 
-// NewGC creates and starts a new GC instance.
-// Maintains the signature expected by mcache.go.
-func NewGC(ctx context.Context, store safeMap.SafeMap, opts ...GCOption) *GC {
-	options := gcOptions{defaultPollInterval: time.Minute}
-	for _, opt := range opts {
-		opt(&options)
-	}
+  // NewGC creates and starts a new GC instance.
+  // Maintains the signature expected by mcache.go.
+  func NewGC(ctx context.Context, store safeMap.SafeMap, opts ...GCOption) *GC {
+        options := gcOptions{defaultPollInterval: time.Minute}
+        for _, opt := range opts {
+                opt(&options)
+        }
 
-	gc := &GC{
-		storage:    store,
-		pq:         make(expiryHeap, 0),
-		keys:       make(map[string]*expiryItem),
-		stopSignal: make(chan struct{}),
-		wakeSignal: make(chan struct{}, 1),
-		options:    options,
-	}
-	heap.Init(&gc.pq)
+        gc := &GC{
+                storage:    store,
+                pq:         make(expiryHeap, 0),
+                keys:       make(map[string]*expiryItem),
+                stopSignal: make(chan struct{}),
+                wakeSignal: make(chan struct{}, 1),
+                options:    options,
+        }
+        heap.Init(&gc.pq)
 
-	gc.wg.Add(1)
-	go gc.run(ctx)
+        gc.wg.Add(1)
+        go gc.run(ctx)
 
-	return gc
-}
+        return gc
+  }
 
-// Expired schedules a key for expiration after the given duration.
-func (gc *GC) Expired(key string, duration time.Duration) {
-	if duration <= 0 {
-		return
-	}
-	expireAt := time.Now().Add(duration)
+  // Expired schedules a key for expiration after the given duration.
+  func (gc *GC) Expired(key string, duration time.Duration) {
+        if duration <= 0 {
+                return
+        }
+        expireAt := time.Now().Add(duration)
 
-	gc.mu.Lock()
-	defer gc.mu.Unlock()
+        gc.mu.Lock()
+        defer gc.mu.Unlock()
 
-	if item, exists := gc.keys[key]; exists {
-		item.expireAt = expireAt
-		// The item.index is always up-to-date thanks to heap.Swap
-		heap.Fix(&gc.pq, item.index)
-	} else {
-		item := &expiryItem{key: key, expireAt: expireAt}
-		heap.Push(&gc.pq, item)
-		gc.keys[key] = item
-	}
+        if item, exists := gc.keys[key]; exists {
+                item.expireAt = expireAt
+                // The item.index is always up-to-date thanks to heap.Swap
+                heap.Fix(&gc.pq, item.index)
+        } else {
+                item := &expiryItem{key: key, expireAt: expireAt}
+                heap.Push(&gc.pq, item)
+                gc.keys[key] = item
+        }
 
-	// If this entry is now the earliest to expire, wake the run loop.
-	if len(gc.pq) > 0 && gc.pq[0].key == key {
-		gc.signalWakeUp()
-	}
-}
+        // If this entry is now the earliest to expire, wake the run loop.
+        if len(gc.pq) > 0 && gc.pq[0].key == key {
+                gc.signalWakeUp()
+        }
+  }
 
-// run is the main loop that waits for and processes expirations.
-func (gc *GC) run(ctx context.Context) {
-	defer gc.wg.Done()
-	defer func() {
-		gc.mu.Lock()
-		if gc.timer != nil {
-			gc.timer.Stop()
-		}
-		gc.mu.Unlock()
-	}()
+  // run is the main loop that waits for and processes expirations.
+  // Fixed: Restructured to avoid busy loops by always blocking on a timer.
+  func (gc *GC) run(ctx context.Context) {
+        defer gc.wg.Done()
 
-	for {
-		nextInterval := gc.calculateNextWakeInterval()
+        for {
+                nextInterval := gc.calculateNextWakeInterval()
 
-		gc.mu.Lock()
-		switch {
-		case nextInterval > 0:
-			if gc.timer == nil {
-				gc.timer = time.NewTimer(nextInterval)
-			} else {
-				if !gc.timer.Stop() {
-					select {
-					case <-gc.timer.C:
-					default:
-					}
-				}
-				gc.timer.Reset(nextInterval)
-			}
-			gc.mu.Unlock()
-		case nextInterval == 0:
-			gc.mu.Unlock()
-		default: // heap is empty
-			if gc.timer != nil {
-				if !gc.timer.Stop() {
-					select {
-					case <-gc.timer.C:
-					default:
-					}
-				}
-				gc.timer = nil
-			}
-			nextInterval = gc.options.defaultPollInterval
-			gc.mu.Unlock()
-		}
+                // Handle immediate processing (keys expired NOW)
+                if nextInterval == 0 {
+                        gc.processExpiredKeys()
+                        continue // Recalculate interval after processing
+                }
 
-		var timerC <-chan time.Time
-		gc.mu.Lock()
-		if gc.timer != nil && nextInterval > 0 {
-			timerC = gc.timer.C
-		}
-		gc.mu.Unlock()
+                // Determine wait duration
+                var waitDuration time.Duration
+                if nextInterval > 0 {
+                        waitDuration = nextInterval
+                } else {
+                        // Heap is empty, use default poll interval
+                        waitDuration = gc.options.defaultPollInterval
+                }
 
-		processNow := nextInterval == 0
+                // Use a timer for waiting - this properly blocks
+                timer := time.NewTimer(waitDuration)
 
-		select {
-		case <-ctx.Done():
-			return
-		case <-gc.stopSignal:
-			return
-		case <-gc.wakeSignal:
-			continue
-		case <-timerC:
-			gc.processExpiredKeys()
-		default:
-			if processNow {
-				gc.processExpiredKeys()
-			} else if nextInterval < 0 {
-				select {
-				case <-time.After(gc.options.defaultPollInterval):
-				case <-ctx.Done():
-					return
-				case <-gc.stopSignal:
-					return
-				case <-gc.wakeSignal:
-					continue
-				}
-			}
-		}
-	}
-}
+                select {
+                case <-ctx.Done():
+                        timer.Stop()
+                        return
+                case <-gc.stopSignal:
+                        timer.Stop()
+                        return
+                case <-gc.wakeSignal:
+                        timer.Stop()
+                        continue
+                case <-timer.C:
+                        // Time to check for expired keys
+                        gc.processExpiredKeys()
+                }
+        }
+  }
 
-func (gc *GC) calculateNextWakeInterval() time.Duration {
-	gc.mu.Lock()
-	defer gc.mu.Unlock()
+  func (gc *GC) calculateNextWakeInterval() time.Duration {
+        gc.mu.Lock()
+        defer gc.mu.Unlock()
 
-	if len(gc.pq) == 0 {
-		return -1
-	}
-	delta := time.Until(gc.pq[0].expireAt)
-	if delta <= 0 {
-		return 0
-	}
-	return delta
-}
+        if len(gc.pq) == 0 {
+                return -1
+        }
+        delta := time.Until(gc.pq[0].expireAt)
+        if delta <= 0 {
+                return 0
+        }
+        return delta
+  }
 
-// processExpiredKeys removes all entries whose expiration time has passed.
-func (gc *GC) processExpiredKeys() {
-	now := time.Now()
-	var keys []string
+  // processExpiredKeys removes all entries whose expiration time has passed.
+  func (gc *GC) processExpiredKeys() {
+        now := time.Now()
+        var keys []string
 
-	gc.mu.Lock()
-	for len(gc.pq) > 0 && !gc.pq[0].expireAt.After(now) {
-		expired := heap.Pop(&gc.pq).(*expiryItem)
-		delete(gc.keys, expired.key)
-		keys = append(keys, expired.key)
-	}
-	gc.mu.Unlock()
+        gc.mu.Lock()
+        for len(gc.pq) > 0 && !gc.pq[0].expireAt.After(now) {
+                expired := heap.Pop(&gc.pq).(*expiryItem)
+                delete(gc.keys, expired.key)
+                keys = append(keys, expired.key)
+        }
+        gc.mu.Unlock()
 
-	if len(keys) > 0 {
-		gc.storage.Flush(keys)
-	}
-}
+        if len(keys) > 0 {
+                gc.storage.Flush(keys)
+        }
+  }
 
-func (gc *GC) signalWakeUp() {
-	select {
-	case gc.wakeSignal <- struct{}{}:
-	default:
-	}
-}
+  func (gc *GC) signalWakeUp() {
+        select {
+        case gc.wakeSignal <- struct{}{}:
+        default:
+        }
+  }
 
-// Stop shuts down the GC loop gracefully.
-func (gc *GC) Stop() {
-	close(gc.stopSignal)
-	gc.wg.Wait()
-}
+  // Stop shuts down the GC loop gracefully.
+  func (gc *GC) Stop() {
+        close(gc.stopSignal)
+        gc.wg.Wait()
+  }
 
-// LenBufferKeyChan reports the number of pending expirations (for compatibility).
-func (gc *GC) LenBufferKeyChan() int {
-	gc.mu.Lock()
-	defer gc.mu.Unlock()
-	return len(gc.pq)
-}
+  // LenBufferKeyChan reports the number of pending expirations (for compatibility).
+  func (gc *GC) LenBufferKeyChan() int {
+        gc.mu.Lock()
+        defer gc.mu.Unlock()
+        return len(gc.pq)
+  }
 
-// Truncate clears all scheduled expirations.
-func (gc *GC) Truncate() {
-	gc.mu.Lock()
-	defer gc.mu.Unlock()
-	gc.pq = make(expiryHeap, 0)
-	gc.keys = make(map[string]*expiryItem)
-	if gc.timer != nil {
-		gc.timer.Stop()
-		gc.timer = nil
-	}
-}
+  // Truncate clears all scheduled expirations.
+  func (gc *GC) Truncate() {
+        gc.mu.Lock()
+        defer gc.mu.Unlock()
+        gc.pq = make(expiryHeap, 0)
+        gc.keys = make(map[string]*expiryItem)
+  }
 
-// RemoveKey removes a key from expiration tracking.
-func (gc *GC) RemoveKey(key string) {
-	gc.mu.Lock()
-	defer gc.mu.Unlock()
+  // RemoveKey removes a key from expiration tracking.
+  func (gc *GC) RemoveKey(key string) {
+        gc.mu.Lock()
+        defer gc.mu.Unlock()
 
-	if item, ok := gc.keys[key]; ok {
-		heap.Remove(&gc.pq, item.index)
-		delete(gc.keys, key)
-	}
-}
+        if item, ok := gc.keys[key]; ok {
+                heap.Remove(&gc.pq, item.index)
+                delete(gc.keys, key)
+        }
+  }


### PR DESCRIPTION
  ## Problem

  The GC goroutines spin at 100% CPU instead of properly blocking/sleeping. This affects all users of the
  library.

  ### Root Cause

  In the `run()` function, the `select` statement has a `default` case that executes immediately when
  `timerC` is nil. This happens when:
  - The heap is empty (`nextInterval < 0`, timer is set to nil)
  - But then `nextInterval` gets reassigned to `defaultPollInterval` (positive value)
  - The condition `gc.timer != nil && nextInterval > 0` is false because timer is nil
  - So `timerC` remains nil, and the `default` case fires immediately

  This creates a tight loop where the goroutine never blocks.

  ## Solution

  Restructured `run()` to always block on a timer:
  - Handle immediate expiration (`nextInterval == 0`) before the select statement
  - Always create a fresh timer for the wait duration
  - Remove the `default` case entirely so select always blocks
  - Removed unused `timer` field from the GC struct

  ## Before/After

  **Before:** GC goroutines constantly in `[runnable]` state
  goroutine 35 [runnable]:
  github.com/OrlovEvgeny/go-mcache/gcmap.(*GC).run(...)

  **After:** GC goroutines properly blocking in `[select]` state
  goroutine 6 [select]:
  github.com/OrlovEvgeny/go-mcache/gcmap.(*GC).run(...)

  ## Testing

  Deployed patched version in production - CPU usage dropped from 100% to ~0.2%.